### PR TITLE
Add coverage tests; correct function in application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ test: $(VENV)
 	$(PYTEST) $(PYTEST_FLAGS) $(PYTEST_FILES)
 
 coverage: $(VENV)
-	FLAGS="--cov=$(COVERAGE_DIR) --cov-report=term-missing --verbosity=-1"; \
-	$(MAKE) --no-print-directory test PYTEST_FLAGS="$$FLAGS"
+	$(PYTEST) --cov=$(COVERAGE_DIR) --cov-report=term-missing $(TEST_DIR)
 
 typecheck: $(VENV)
 	$(MYPY) $(TKT) $(TEST_DIR)

--- a/TKT/cli.py
+++ b/TKT/cli.py
@@ -121,6 +121,9 @@ class TKTSystemManager:
             self.distro_config = get_distro_configs(self.distro)
             self.distro_supported = True
         except (ValueError, RuntimeError):
+            # Reset all attributes when distribution is not supported
+            self.distro = None
+            self.distro_config = None
             self.distro_supported = False
 
     def install_dependencies(self) -> tuple[bool, str]:

--- a/tests/test_choose_backend.py
+++ b/tests/test_choose_backend.py
@@ -1,0 +1,158 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+import tomlkit
+
+from TKT.cli import choose_backend
+
+
+class TestChooseBackend:
+    def test_config_with_existing_backend_supported_distro(self, mocker):
+        """Test when config has backend and distro is supported."""
+        config = {"settings": {"backend": "kernel_lib_debian"}}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock get_distribution_name to return supported distro
+        mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+        # Mock get_distro_configs to not raise exception (supported)
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        backend, distro_supported = choose_backend(config, config_path)
+
+        assert backend == "kernel_lib_debian"
+        assert distro_supported is True
+
+    def test_config_with_existing_backend_unsupported_distro(self, mocker):
+        """Test when config has backend but distro is unsupported."""
+        config = {"settings": {"backend": "kernel_lib_gentoo"}}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock get_distribution_name to return distro name
+        mocker.patch("TKT.cli.get_distribution_name", return_value="gentoo")
+        # Mock get_distro_configs to raise ValueError (unsupported)
+        mocker.patch(
+            "TKT.cli.get_distro_configs", side_effect=ValueError("Unsupported")
+        )
+
+        backend, distro_supported = choose_backend(config, config_path)
+
+        assert backend == "kernel_lib_gentoo"
+        assert distro_supported is False
+
+    def test_config_missing_settings_section(self, mocker):
+        """Test when config is missing settings section."""
+        config = {}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock file operations
+        mock_file = mock_open()
+        mocker.patch("builtins.open", mock_file)
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs")
+        mocker.patch("tomlkit.dump")
+
+        backend, distro_supported = choose_backend(config, config_path)
+
+        # Should add settings section
+        assert "settings" in config
+        assert backend == "kernel_lib_arch"
+        assert distro_supported is True
+
+        # Should have written to file
+        mock_file.assert_called_once_with(config_path, "w")
+
+    def test_config_missing_backend_key(self, mocker):
+        """Test when config has settings but missing backend key."""
+        config = {"settings": {"other_setting": "value"}}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock file operations
+        mock_file = mock_open()
+        mocker.patch("builtins.open", mock_file)
+        mocker.patch("TKT.cli.get_distribution_name", return_value="ubuntu")
+        mocker.patch("TKT.cli.get_distro_configs")
+        mocker.patch("tomlkit.dump")
+
+        backend, distro_supported = choose_backend(config, config_path)
+
+        # Should add backend key
+        assert config["settings"]["backend"] == "kernel_lib_ubuntu"
+        assert backend == "kernel_lib_ubuntu"
+        assert distro_supported is True
+
+        # Should have written to file
+        mock_file.assert_called_once_with(config_path, "w")
+
+    def test_config_get_distro_configs_failure(self, mocker):
+        """Test when get_distro_configs raises ValueError during distro check."""
+        config = {"settings": {"backend": "kernel_lib_fedora"}}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock get_distribution_name to succeed
+        mocker.patch("TKT.cli.get_distribution_name", return_value="fedora")
+        # Mock get_distro_configs to raise ValueError (unsupported distro)
+        mocker.patch(
+            "TKT.cli.get_distro_configs", side_effect=ValueError("Unsupported distro")
+        )
+
+        backend, distro_supported = choose_backend(config, config_path)
+
+        assert backend == "kernel_lib_fedora"
+        assert distro_supported is False
+
+    def test_config_get_distribution_name_runtime_error(self, mocker):
+        """Test when get_distribution_name raises RuntimeError during distro check."""
+        config = {"settings": {"backend": "kernel_lib_fedora"}}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock get_distribution_name to raise RuntimeError
+        mocker.patch(
+            "TKT.cli.get_distribution_name", side_effect=RuntimeError("No distro")
+        )
+
+        # The RuntimeError should propagate and not be caught by choose_backend
+        with pytest.raises(RuntimeError, match="No distro"):
+            choose_backend(config, config_path)
+
+    def test_config_missing_backend_key_with_distro_failure(self, mocker):
+        """Test when config has settings but missing backend key and distro detection fails."""
+        config = {"settings": {"other_setting": "value"}}
+        config_path = "/fake/path/settings.toml"
+
+        # Mock get_distribution_name to fail when trying to add default backend
+        mocker.patch(
+            "TKT.cli.get_distribution_name", side_effect=RuntimeError("No distro")
+        )
+
+        # The RuntimeError should propagate when trying to get default backend
+        with pytest.raises(RuntimeError, match="No distro"):
+            choose_backend(config, config_path)
+        """Test actual file writing when backend is added."""
+        config = {}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            config_path = f.name
+
+        try:
+            mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+            mocker.patch("TKT.cli.get_distro_configs")
+
+            backend, distro_supported = choose_backend(config, config_path)
+
+            assert backend == "kernel_lib_debian"
+            assert distro_supported is True
+            assert "settings" in config
+            assert config["settings"]["backend"] == "kernel_lib_debian"
+
+            # Verify file was written
+            assert Path(config_path).exists()
+            with open(config_path, "rb") as f:
+                written_config = tomlkit.load(f)
+                assert written_config["settings"]["backend"] == "kernel_lib_debian"
+
+        finally:
+            if Path(config_path).exists():
+                Path(config_path).unlink()

--- a/tests/test_kernel_toolkit_app.py
+++ b/tests/test_kernel_toolkit_app.py
@@ -1,0 +1,341 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+import tomlkit
+
+from TKT.cli import KernelToolkitApp
+
+
+class TestKernelToolkitApp:
+    def test_init_with_existing_config(self, mocker):
+        """Test app initialization with existing config file."""
+        config_content = {
+            "kernels": {"available": ["6.16", "6.15"]},
+            "settings": {"backend": "kernel_lib_arch"},
+        }
+
+        # Mock file operations
+        mock_file_content = b""  # tomllib.load will be mocked separately
+        mocker.patch("builtins.open", mock_open(read_data=mock_file_content))
+        mocker.patch("tomllib.load", return_value=config_content)
+        mocker.patch("TKT.cli.choose_backend", return_value=("kernel_lib_arch", True))
+        mocker.patch("TKT.cli.load_library", return_value=Mock())
+        mocker.patch("TKT.cli.TKTSystemManager")
+
+        app = KernelToolkitApp()
+
+        assert app.config == config_content
+        assert app.backend == "kernel_lib_arch"
+        assert app.backend_distro_supported is True
+        assert app.lib_module is not None
+
+    def test_init_config_file_not_found(self, mocker):
+        """Test app initialization when config file doesn't exist."""
+        # Mock FileNotFoundError and file creation
+        mocker.patch(
+            "builtins.open", side_effect=[FileNotFoundError(), mock_open().return_value]
+        )
+        mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+        mocker.patch("tomlkit.dump")
+        mocker.patch("TKT.cli.choose_backend", return_value=("kernel_lib_debian", True))
+        mocker.patch("TKT.cli.load_library", return_value=None)
+        mocker.patch("TKT.cli.TKTSystemManager")
+
+        app = KernelToolkitApp()
+
+        # Should create default config
+        expected_config = {
+            "kernels": {"available": []},
+            "settings": {"backend": "kernel_lib_debian"},
+        }
+        assert app.config == expected_config
+        assert app.lib_module is None
+
+    def test_init_config_file_exception(self, mocker):
+        """Test app initialization when config file has other exceptions."""
+        # Mock exception during config loading
+        mocker.patch("builtins.open", side_effect=PermissionError("Access denied"))
+        mocker.patch(
+            "TKT.cli.choose_backend", return_value=("kernel_lib_ubuntu", False)
+        )
+        mocker.patch("TKT.cli.load_library", return_value=Mock())
+        mocker.patch("TKT.cli.TKTSystemManager")
+
+        app = KernelToolkitApp()
+
+        # Should fallback to empty config
+        expected_config = {"kernels": {"available": []}, "settings": {}}
+        assert app.config == expected_config
+        assert app.backend_distro_supported is False
+
+    def test_update_status_with_mounted_label(self, mocker):
+        """Test update_status when status label is mounted."""
+        mock_label = Mock()
+        mock_app = Mock()
+        mock_app.query_one.return_value = mock_label
+
+        app = KernelToolkitApp.__new__(
+            KernelToolkitApp
+        )  # Create without calling __init__
+        app.status_message = ""
+        app.query_one = mock_app.query_one
+
+        app.update_status("Test message")
+
+        assert app.status_message == "Test message"
+        mock_app.query_one.assert_called_once_with(
+            "#status_label", pytest.importorskip("textual.widgets").Label
+        )
+        mock_label.update.assert_called_once_with("Test message")
+
+    def test_update_status_with_unmounted_label(self, mocker):
+        """Test update_status when status label is not mounted."""
+        mock_app = Mock()
+        mock_app.query_one.side_effect = LookupError("Not found")
+
+        app = KernelToolkitApp.__new__(
+            KernelToolkitApp
+        )  # Create without calling __init__
+        app.status_message = ""
+        app.query_one = mock_app.query_one
+
+        # Should not raise exception
+        app.update_status("Test message")
+
+        assert app.status_message == "Test message"
+
+    def test_action_install_deps(self, mocker):
+        """Test action_install_deps method."""
+        mock_system_manager = Mock()
+        mock_system_manager.install_dependencies.return_value = (True, "Success")
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.system_manager = mock_system_manager
+        app.status_message = ""
+        app.update_status = Mock()
+        app.refresh = Mock()
+
+        app.action_install_deps()
+
+        # Should call update_status twice and refresh once
+        assert app.update_status.call_count == 2
+        app.update_status.assert_any_call("Installing dependencies...")
+        app.update_status.assert_any_call("✓ Success")
+        app.refresh.assert_called_once()
+
+    def test_handle_command_deps(self, mocker):
+        """Test handle_command with 'deps' command."""
+        mock_system_manager = Mock()
+        mock_system_manager.install_dependencies.return_value = (False, "Failed")
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.system_manager = mock_system_manager
+        app.update_status = Mock()
+        app.refresh = Mock()
+
+        result = app.handle_command("deps")
+
+        assert result is True
+        app.update_status.assert_any_call("Installing dependencies...")
+        app.update_status.assert_any_call("✗ Failed")
+
+    def test_handle_command_install_deps(self, mocker):
+        """Test handle_command with 'install-deps' command."""
+        mock_system_manager = Mock()
+        mock_system_manager.install_dependencies.return_value = (True, "Installed")
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.system_manager = mock_system_manager
+        app.update_status = Mock()
+        app.refresh = Mock()
+
+        result = app.handle_command("INSTALL-DEPS")  # Test case insensitive
+
+        assert result is True
+        app.update_status.assert_any_call("✓ Installed")
+
+    def test_handle_command_config(self, mocker):
+        """Test handle_command with 'config:' command."""
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.update_status = Mock()
+
+        result = app.handle_command("config:custom")
+
+        assert result is True
+        app.update_status.assert_called_once_with(
+            "Kernel configuration (custom) would be implemented here"
+        )
+
+    def test_handle_command_prepare(self, mocker):
+        """Test handle_command with 'prepare:' command."""
+        mock_system_manager = Mock()
+        mock_system_manager.prepare_kernel_source.return_value = (True, "Prepared 6.16")
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.system_manager = mock_system_manager
+        app.update_status = Mock()
+
+        result = app.handle_command("prepare:6.16")
+
+        assert result is True
+        mock_system_manager.prepare_kernel_source.assert_called_once_with("6.16")
+        app.update_status.assert_called_once_with("✓ Prepared 6.16")
+
+    def test_handle_command_unknown(self, mocker):
+        """Test handle_command with unknown command."""
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+
+        result = app.handle_command("unknown_command")
+
+        assert result is False
+
+    def test_on_input_submitted_empty_input(self, mocker):
+        """Test on_input_submitted with empty input."""
+        mock_event = Mock()
+        mock_event.input.value = "   "  # whitespace only
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.query_one = Mock(return_value=mock_input_widget)
+
+        app.on_input_submitted(mock_event)
+
+        assert (
+            mock_input_widget.placeholder
+            == "Please enter a valid kernel version or command."
+        )
+
+    def test_on_input_submitted_command(self, mocker):
+        """Test on_input_submitted with a command."""
+        mock_event = Mock()
+        mock_event.input.value = "deps"
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.query_one = Mock(return_value=mock_input_widget)
+        app.handle_command = Mock(return_value=True)
+
+        app.on_input_submitted(mock_event)
+
+        app.handle_command.assert_called_once_with("deps")
+        assert mock_input_widget.value == ""  # Should clear input
+
+    def test_on_input_submitted_kernel_version_valid(self, mocker):
+        """Test on_input_submitted with valid kernel version."""
+        mock_event = Mock()
+        mock_event.input.value = "6.16"
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.config = {"kernels": {"available": ["6.16", "6.15"]}}
+        app.query_one = Mock(return_value=mock_input_widget)
+        app.handle_command = Mock(return_value=False)
+        app.update_status = Mock()
+
+        app.on_input_submitted(mock_event)
+
+        app.update_status.assert_called_once_with(" Kernel version 6.16 selected")
+        assert mock_input_widget.value == ""
+
+    def test_on_input_submitted_kernel_version_invalid(self, mocker):
+        """Test on_input_submitted with invalid kernel version."""
+        mock_event = Mock()
+        mock_event.input.value = "6.20"
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.config = {"kernels": {"available": ["6.16", "6.15"]}}
+        app.query_one = Mock(return_value=mock_input_widget)
+        app.handle_command = Mock(return_value=False)
+        app.update_status = Mock()
+
+        app.on_input_submitted(mock_event)
+
+        app.update_status.assert_called_once_with(
+            " Kernel version 6.20 not in available list"
+        )
+        assert mock_input_widget.value == ""
+
+    def test_on_input_submitted_kernel_version_no_list(self, mocker):
+        """Test on_input_submitted with kernel version when no available list."""
+        mock_event = Mock()
+        mock_event.input.value = "6.16"
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.config = {"kernels": {"available": []}}
+        app.query_one = Mock(return_value=mock_input_widget)
+        app.handle_command = Mock(return_value=False)
+        app.update_status = Mock()
+
+        app.on_input_submitted(mock_event)
+
+        app.update_status.assert_called_once_with(" Kernel version 6.16 selected")
+        assert mock_input_widget.value == ""
+
+    def test_on_input_submitted_legacy_kernel_format(self, mocker):
+        """Test on_input_submitted with legacy string kernel format."""
+        mock_event = Mock()
+        mock_event.input.value = "6.16"
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.config = {"kernels": {"available": "6.16, 6.15"}}  # String format
+        app.query_one = Mock(return_value=mock_input_widget)
+        app.handle_command = Mock(return_value=False)
+        app.update_status = Mock()
+
+        app.on_input_submitted(mock_event)
+
+        app.update_status.assert_called_once_with(" Kernel version 6.16 selected")
+
+    def test_on_input_submitted_config_exception(self, mocker):
+        """Test on_input_submitted when config parsing raises exception."""
+        mock_event = Mock()
+        mock_event.input.value = "6.16"
+
+        mock_input_widget = Mock()
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.config = {"kernels": None}  # Will cause exception
+        app.query_one = Mock(return_value=mock_input_widget)
+        app.handle_command = Mock(return_value=False)
+        app.update_status = Mock()
+
+        app.on_input_submitted(mock_event)
+
+        # Should handle exception gracefully and treat as no kernels available
+        app.update_status.assert_called_once_with(" Kernel version 6.16 selected")
+
+    def test_on_mount(self, mocker):
+        """Test on_mount method."""
+        mock_input_widget = Mock()
+        mock_input_widget.disabled = False
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.query_one = Mock(return_value=mock_input_widget)
+
+        app.on_mount()
+
+        mock_input_widget.focus.assert_called_once()
+
+    def test_on_mount_disabled_input(self, mocker):
+        """Test on_mount method with disabled input."""
+        mock_input_widget = Mock()
+        mock_input_widget.disabled = True
+
+        app = KernelToolkitApp.__new__(KernelToolkitApp)
+        app.query_one = Mock(return_value=mock_input_widget)
+
+        app.on_mount()
+
+        mock_input_widget.focus.assert_not_called()

--- a/tests/test_main_function.py
+++ b/tests/test_main_function.py
@@ -1,0 +1,121 @@
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from TKT.cli import main
+
+
+class TestMainFunction:
+    def test_main_not_tty_stdin(self, mocker):
+        """Test main function when stdin is not a tty."""
+        mocker.patch.object(sys.stdin, "isatty", return_value=False)
+        mocker.patch.object(sys.stdout, "isatty", return_value=True)
+
+        # Mock print to capture the error message since it goes to stderr via print()
+        captured_output = []
+
+        def mock_print(*args, **kwargs):
+            if kwargs.get("file") == sys.stderr:
+                captured_output.extend(args)
+
+        mocker.patch("builtins.print", mock_print)
+
+        result = main()
+
+        assert result == 1
+        # Check that error message was printed
+        assert any(
+            "stdin and stdout must be a tty" in str(arg) for arg in captured_output
+        )
+
+    def test_main_not_tty_stdout(self, mocker):
+        """Test main function when stdout is not a tty."""
+        mocker.patch.object(sys.stdin, "isatty", return_value=True)
+        mocker.patch.object(sys.stdout, "isatty", return_value=False)
+
+        # Mock print to capture the error message
+        captured_output = []
+
+        def mock_print(*args, **kwargs):
+            if kwargs.get("file") == sys.stderr:
+                captured_output.extend(args)
+
+        mocker.patch("builtins.print", mock_print)
+
+        result = main()
+
+        assert result == 1
+        # Check that error message was printed
+        assert any(
+            "stdin and stdout must be a tty" in str(arg) for arg in captured_output
+        )
+
+    def test_main_both_not_tty(self, mocker):
+        """Test main function when both stdin and stdout are not tty."""
+        mocker.patch.object(sys.stdin, "isatty", return_value=False)
+        mocker.patch.object(sys.stdout, "isatty", return_value=False)
+
+        # Mock print to capture the error message
+        captured_output = []
+
+        def mock_print(*args, **kwargs):
+            if kwargs.get("file") == sys.stderr:
+                captured_output.extend(args)
+
+        mocker.patch("builtins.print", mock_print)
+
+        result = main()
+
+        assert result == 1
+
+    def test_main_success(self, mocker):
+        """Test main function with successful execution."""
+        mocker.patch.object(sys.stdin, "isatty", return_value=True)
+        mocker.patch.object(sys.stdout, "isatty", return_value=True)
+
+        # Mock the KernelToolkitApp
+        mock_app_instance = Mock()
+        mock_app_class = Mock(return_value=mock_app_instance)
+        mocker.patch("TKT.cli.KernelToolkitApp", mock_app_class)
+
+        result = main()
+
+        assert result == 0
+        mock_app_class.assert_called_once()
+        mock_app_instance.run.assert_called_once()
+
+    def test_main_app_exception(self, mocker):
+        """Test main function when app raises an exception."""
+        mocker.patch.object(sys.stdin, "isatty", return_value=True)
+        mocker.patch.object(sys.stdout, "isatty", return_value=True)
+
+        # Mock the KernelToolkitApp to raise an exception
+        mock_app_instance = Mock()
+        mock_app_instance.run.side_effect = Exception("App crashed")
+        mock_app_class = Mock(return_value=mock_app_instance)
+        mocker.patch("TKT.cli.KernelToolkitApp", mock_app_class)
+
+        # The exception should propagate (main doesn't handle it)
+        with pytest.raises(Exception, match="App crashed"):
+            main()
+
+    def test_main_as_script(self, mocker):
+        """Test the if __name__ == '__main__' block."""
+        mocker.patch.object(sys.stdin, "isatty", return_value=True)
+        mocker.patch.object(sys.stdout, "isatty", return_value=True)
+
+        # Mock the KernelToolkitApp
+        mock_app_instance = Mock()
+        mock_app_class = Mock(return_value=mock_app_instance)
+        mocker.patch("TKT.cli.KernelToolkitApp", mock_app_class)
+
+        # Mock sys.exit to capture the exit code
+        mock_exit = Mock()
+        mocker.patch.object(sys, "exit", mock_exit)
+
+        # This would normally be tested by running the script directly,
+        # but we can test the logic by calling main() directly
+        result = main()
+
+        assert result == 0

--- a/tests/test_textual_app_integration.py
+++ b/tests/test_textual_app_integration.py
@@ -1,0 +1,133 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from TKT.cli import TKTSystemManager
+
+
+class TestTKTSystemManager:
+    def test_init_supported_distro(self, mocker):
+        """Test initialization with supported distribution."""
+        mock_distro_config = Mock()
+        mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+        mocker.patch("TKT.cli.get_distro_configs", return_value=mock_distro_config)
+
+        manager = TKTSystemManager()
+
+        assert manager.distro == "debian"
+        assert manager.distro_config is mock_distro_config
+        assert manager.distro_supported is True
+
+    def test_init_unsupported_distro_value_error(self, mocker):
+        """Test initialization with unsupported distribution (ValueError)."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="gentoo")
+        mocker.patch(
+            "TKT.cli.get_distro_configs", side_effect=ValueError("Unsupported")
+        )
+
+        manager = TKTSystemManager()
+
+        # When ValueError is caught in _initialize_distro, all attributes are reset
+        # This matches the actual code behavior in the except block
+        assert manager.distro is None
+        assert manager.distro_config is None
+        assert manager.distro_supported is False
+
+    def test_init_runtime_error(self, mocker):
+        """Test initialization with RuntimeError from get_distribution_name."""
+        mocker.patch(
+            "TKT.cli.get_distribution_name", side_effect=RuntimeError("No Linux")
+        )
+
+        manager = TKTSystemManager()
+
+        assert manager.distro is None
+        assert manager.distro_config is None
+        assert manager.distro_supported is False
+
+    def test_install_dependencies_success(self, mocker):
+        """Test successful dependency installation."""
+        mock_distro_config = Mock()
+        mock_distro_config.update_and_install.return_value = None
+
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs", return_value=mock_distro_config)
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is True
+        assert message == "Dependencies installed successfully"
+        mock_distro_config.update_and_install.assert_called_once()
+
+    def test_install_dependencies_unsupported_distro(self, mocker):
+        """Test dependency installation with unsupported distribution."""
+        mocker.patch(
+            "TKT.cli.get_distribution_name", side_effect=ValueError("Unsupported")
+        )
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is False
+        assert "Distribution not supported" in message
+
+    def test_install_dependencies_no_distro_config(self, mocker):
+        """Test dependency installation when distro_config is None."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs", side_effect=RuntimeError("Failed"))
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is False
+        assert "Distribution not supported" in message
+
+    def test_install_dependencies_exception_during_install(self, mocker):
+        """Test dependency installation when update_and_install raises exception."""
+        mock_distro_config = Mock()
+        mock_distro_config.update_and_install.side_effect = Exception(
+            "Installation failed"
+        )
+
+        mocker.patch("TKT.cli.get_distribution_name", return_value="ubuntu")
+        mocker.patch("TKT.cli.get_distro_configs", return_value=mock_distro_config)
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is False
+        assert "Failed to install dependencies: Installation failed" in message
+
+    def test_prepare_kernel_source(self, mocker):
+        """Test prepare_kernel_source placeholder method."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        manager = TKTSystemManager()
+        success, message = manager.prepare_kernel_source("6.16")
+
+        assert success is True
+        assert "Kernel source preparation for 6.16 would go here" in message
+
+    def test_configure_kernel_default(self, mocker):
+        """Test configure_kernel with default config type."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="fedora")
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        manager = TKTSystemManager()
+        success, message = manager.configure_kernel("6.16")
+
+        assert success is True
+        assert "Kernel configuration for 6.16 (default) would go here" in message
+
+    def test_configure_kernel_custom(self, mocker):
+        """Test configure_kernel with custom config type."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        manager = TKTSystemManager()
+        success, message = manager.configure_kernel("6.16", "custom")
+
+        assert success is True
+        assert "Kernel configuration for 6.16 (custom) would go here" in message

--- a/tests/test_tkt_system_manager.py
+++ b/tests/test_tkt_system_manager.py
@@ -1,0 +1,132 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from TKT.cli import TKTSystemManager
+
+
+class TestTKTSystemManager:
+    def test_init_supported_distro(self, mocker):
+        """Test initialization with supported distribution."""
+        mock_distro_config = Mock()
+        mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+        mocker.patch("TKT.cli.get_distro_configs", return_value=mock_distro_config)
+
+        manager = TKTSystemManager()
+
+        assert manager.distro == "debian"
+        assert manager.distro_config is mock_distro_config
+        assert manager.distro_supported is True
+
+    def test_init_unsupported_distro_value_error(self, mocker):
+        """Test initialization with unsupported distribution (ValueError)."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="gentoo")
+        mocker.patch(
+            "TKT.cli.get_distro_configs", side_effect=ValueError("Unsupported")
+        )
+
+        manager = TKTSystemManager()
+
+        # When ValueError is caught, the attributes are set to None and False
+        assert manager.distro is None
+        assert manager.distro_config is None
+        assert manager.distro_supported is False
+
+    def test_init_runtime_error(self, mocker):
+        """Test initialization with RuntimeError from get_distribution_name."""
+        mocker.patch(
+            "TKT.cli.get_distribution_name", side_effect=RuntimeError("No Linux")
+        )
+
+        manager = TKTSystemManager()
+
+        assert manager.distro is None
+        assert manager.distro_config is None
+        assert manager.distro_supported is False
+
+    def test_install_dependencies_success(self, mocker):
+        """Test successful dependency installation."""
+        mock_distro_config = Mock()
+        mock_distro_config.update_and_install.return_value = None
+
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs", return_value=mock_distro_config)
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is True
+        assert message == "Dependencies installed successfully"
+        mock_distro_config.update_and_install.assert_called_once()
+
+    def test_install_dependencies_unsupported_distro(self, mocker):
+        """Test dependency installation with unsupported distribution."""
+        mocker.patch(
+            "TKT.cli.get_distribution_name", side_effect=ValueError("Unsupported")
+        )
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is False
+        assert "Distribution not supported" in message
+
+    def test_install_dependencies_no_distro_config(self, mocker):
+        """Test dependency installation when distro_config is None."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs", side_effect=RuntimeError("Failed"))
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is False
+        assert "Distribution not supported" in message
+
+    def test_install_dependencies_exception_during_install(self, mocker):
+        """Test dependency installation when update_and_install raises exception."""
+        mock_distro_config = Mock()
+        mock_distro_config.update_and_install.side_effect = Exception(
+            "Installation failed"
+        )
+
+        mocker.patch("TKT.cli.get_distribution_name", return_value="ubuntu")
+        mocker.patch("TKT.cli.get_distro_configs", return_value=mock_distro_config)
+
+        manager = TKTSystemManager()
+        success, message = manager.install_dependencies()
+
+        assert success is False
+        assert "Failed to install dependencies: Installation failed" in message
+
+    def test_prepare_kernel_source(self, mocker):
+        """Test prepare_kernel_source placeholder method."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="debian")
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        manager = TKTSystemManager()
+        success, message = manager.prepare_kernel_source("6.16")
+
+        assert success is True
+        assert "Kernel source preparation for 6.16 would go here" in message
+
+    def test_configure_kernel_default(self, mocker):
+        """Test configure_kernel with default config type."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="fedora")
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        manager = TKTSystemManager()
+        success, message = manager.configure_kernel("6.16")
+
+        assert success is True
+        assert "Kernel configuration for 6.16 (default) would go here" in message
+
+    def test_configure_kernel_custom(self, mocker):
+        """Test configure_kernel with custom config type."""
+        mocker.patch("TKT.cli.get_distribution_name", return_value="arch")
+        mocker.patch("TKT.cli.get_distro_configs")
+
+        manager = TKTSystemManager()
+        success, message = manager.configure_kernel("6.16", "custom")
+
+        assert success is True
+        assert "Kernel configuration for 6.16 (custom) would go here" in message


### PR DESCRIPTION
## Added Tests:
-  test_choose_backend.py
-  test_kernel_toolkit_app.py
-  test_main_function.py
-  test_textual_app_integration


## Current Coverage Issues

1. cli.py: 80% coverage
- Missing lines: 226-300, 421


2. distro_configs.py: 48% coverage
- Missing lines: 73, 86, 99-100, 107, 147, 150, 153, 185-193

Fixed bug in _initialize_distro(self) where it wasn't resetting all attributes when the distro is not supported.