### PR TITLE
Linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ typecheck: $(VENV)
 	$(MYPY) $(TKT) $(TEST_DIR)
 
 lint: $(VENV)
-	$(RUFF) check $(TKT) $(TEST_DIR)
+	$(RUFF) check $(TKT) $(TEST_DIR)/test_*.py
 
 format: $(VENV)
 	$(BLACK) $(TKT) $(TEST_DIR)

--- a/tests/test_choose_backend.py
+++ b/tests/test_choose_backend.py
@@ -1,7 +1,6 @@
-import os
 import tempfile
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import mock_open
 
 import pytest
 import tomlkit

--- a/tests/test_kernel_toolkit_app.py
+++ b/tests/test_kernel_toolkit_app.py
@@ -1,10 +1,6 @@
-import os
-import tempfile
-from pathlib import Path
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, mock_open
 
 import pytest
-import tomlkit
 
 from TKT.cli import KernelToolkitApp
 

--- a/tests/test_main_function.py
+++ b/tests/test_main_function.py
@@ -1,5 +1,5 @@
 import sys
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/test_textual_app_integration.py
+++ b/tests/test_textual_app_integration.py
@@ -1,6 +1,4 @@
-from unittest.mock import Mock, patch
-
-import pytest
+from unittest.mock import Mock
 
 from TKT.cli import TKTSystemManager
 


### PR DESCRIPTION
I'm making a small modification to the `make lint` command. For some reason, `ruff` doesn't detect the python files under the `test` directory, so using the wildcard is necessary.