### PR TITLE
feat: create helper function to parse releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ omit = [
     "__main__.py",
 ]
 
+[tool.coverage.report]
+exclude_also = [
+    'if __name__ == "__main__"',
+]
+
 [project]
 name = "the-kernel-toolkit"
 version = "0.1.0"


### PR DESCRIPTION
The `get_files_from_releases` function is a helper function that returns a list of immutable objects with data on each released kernel. Each information related to a file can be accessed by using its respective attribute:
```
class FileData:
    name: str
    size: FileSize
    updated_at: datetime
    digest: str
    url: str
    version: str
    tag: str
    distro: str
    scheduler: str
    compiler: str
```